### PR TITLE
feat: add url option

### DIFF
--- a/Detox.js
+++ b/Detox.js
@@ -131,6 +131,7 @@ class Detox extends Helper {
       launchApp: true,
       reuse: false,
       reloadReactNative: false,
+      url: undefined,
     };
 
     const detoxConf = require(path.join(
@@ -173,7 +174,10 @@ class Detox extends Helper {
     }
     
     if (this.options.reloadReactNative) {
-      return this.device.launchApp({ newInstance: true });
+      await this.device.launchApp({
+        newInstance: true,
+        url: this.options.url
+      });
     }
   }
 
@@ -185,7 +189,7 @@ class Detox extends Helper {
     if (this.options.reloadReactNative) {
       await this.device.reloadReactNative();
     } else {
-      await this.device.launchApp({ newInstance: true });
+      await this.device.launchApp({ newInstance: true, url: this.options.url });
     }
   }
 


### PR DESCRIPTION
Adds a URL option that is used when launching the application with Detox.

Simplifies integration with tools like Expo, where a bundle URL needs to be used to launch into the correct Expo bundle/app via an Expo Dev Client.

Example usage:

```typescript
import {
  config as baseConfig,
} from './config/codecept-base.conf';

const metroUrl = `http://localhost:8081/index.bundle?platform=android&disableOnboarding=1`;
const appUrl = `exp+myapp://expo-development-client/?url=${encodeURIComponent(
  metroUrl,
)}`;

export const config: CodeceptJS.MainConfig = {
  ...baseConfig,
  helpers: {
    ...(baseConfig.helpers || {}),
    Detox: {
      configuration: 'android.emu.debug',
      reloadReactNative: false,
      require: '@codeceptjs/detox-helper',
      url: appUrl,
    },
  },
};
```

Typically in a Detox test with Expo, you might use `launchApp` passing in the app/bundle URL at the beginning of your test(s). Previously, we used a custom CodeceptJS helper to accomplish this (a simplified version of the same solution that `detox-expo-helpers` provided), but this was less reliable on Android than utilizing this `url` option method, and this change seems minimally invasive upstream -- and not much to maintain, given the length of this PR.